### PR TITLE
Bump version to v2.4.0-tchap-rc.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "matrix-react-sdk",
-  "version": "2.4.0-tchap",
+  "version": "2.4.0-tchap-rc.1",
   "description": "SDK for tchap-web using React",
   "author": "MinArm/DINUM/matrix.org",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "matrix-react-sdk",
-  "version": "2.3.7-tchap",
+  "version": "2.4.0-tchap",
   "description": "SDK for tchap-web using React",
   "author": "MinArm/DINUM/matrix.org",
   "repository": {


### PR DESCRIPTION
The accurate version numbers are needed for the upgrade banner to appear. https://github.com/tchapgouv/tchap-web/issues/183